### PR TITLE
provide required arg to wp_kses

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -300,7 +300,7 @@ function settings() {
   register_setting('intercom', 'intercom');
   if (isset($_POST['_wpnonce']) and wp_verify_nonce($_POST[ '_wpnonce'], 'intercom-update')
       and isset($_POST[ 'intercom-submit' ] ) and current_user_can('manage_options')) {
-    $validator = new Validator($_POST["intercom"], function($x) { return wp_kses(trim($x)); });
+    $validator = new Validator($_POST["intercom"], function($x) { return wp_kses(trim($x), array()); });
     update_option("intercom-app-id", $validator->validAppId());
     update_option("intercom-secret", $validator->validSecret());
     wp_safe_redirect(wp_get_referer());


### PR DESCRIPTION
https://codex.wordpress.org/Function_Reference/wp_kses looks like the second argument is required, even though it specifies a default :/