### PR TITLE
Update the signup link to point to Wordpress-specific signup

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -148,7 +148,7 @@ END;
   {
     $app_id = $this->getSettings()['app_id'];
     if(!$app_id) {
-      return '<p>Need an Intercom account? <a target="_blank" href="https://app.intercom.io/a/get_started">Get started</a>.</p>';
+      return '<p>Need an Intercom account? <a target="_blank" href="https://app.intercom.io/a/get_started/add_people?signupMethod=integrate&userSource=wordpress">Get started</a>.</p>';
     } else {
       return '';
     }


### PR DESCRIPTION
We now have a Wordpress-specific signup flow that's live, so we can point our signup link directly to that flow, which makes signing up a lot easier.

/cc @bobjflong 