### PR TITLE
Capital P, dangit

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Intercom
 Plugin URI: https://wordpress.org/plugins/intercom
-Description: Official <a href="https://www.intercom.io">Intercom</a> support for Wordpress.
+Description: Official <a href="https://www.intercom.io">Intercom</a> support for WordPress.
 Author: Bob Long
 Author URI: https://www.intercom.io
 Version: 2.2.2
@@ -81,8 +81,8 @@ END;
   public function htmlUnclosed()
   {
     $settings = $this->getSettings();
-    $app_id = WordpressEscaper::escAttr($settings['app_id']);
-    $secret = WordpressEscaper::escAttr($settings['secret']);
+    $app_id = WordPressEscaper::escAttr($settings['app_id']);
+    $secret = WordPressEscaper::escAttr($settings['secret']);
 
     if (empty($secret)) {
       $secret_row_style = 'display: none;';
@@ -98,7 +98,7 @@ END;
     }
 
     if ($_GET['appId']) {
-      $app_id = WordpressEscaper::escAttr($_GET['appId']);
+      $app_id = WordPressEscaper::escAttr($_GET['appId']);
       $dismissable_message = $this->dismissibleMessage('We’ve copied your new Intercom app ID below. Click to save changes and then close this window to finish signing up for Intercom.');
     }
 
@@ -223,7 +223,7 @@ class SnippetSettings
   private function mergeConstants($settings) {
     foreach($this->constants as $key => $value) {
       if (defined($key)) {
-        $const_val = WordpressEscaper::escJS(constant($key));
+        $const_val = WordPressEscaper::escJS(constant($key));
         $settings = array_merge($settings, array($value => $const_val));
       }
     }
@@ -239,7 +239,7 @@ class SnippetSettings
   }
 }
 
-class WordpressEscaper
+class WordPressEscaper
 {
   public static function escAttr($value)
   {
@@ -279,7 +279,7 @@ class IntercomUser
     }
     if (!empty($this->wordpress_user->user_email))
     {
-      $this->settings["email"] = WordpressEscaper::escJS($this->wordpress_user->user_email);
+      $this->settings["email"] = WordPressEscaper::escJS($this->wordpress_user->user_email);
     }
     return $this->settings;
   }
@@ -324,8 +324,8 @@ function add_intercom_snippet()
 {
   $options = get_option('intercom');
   $snippet_settings = new SnippetSettings(
-    array("app_id" => WordpressEscaper::escJS($options['app_id'])),
-    WordpressEscaper::escJS($options['secret']),
+    array("app_id" => WordPressEscaper::escJS($options['app_id'])),
+    WordPressEscaper::escJS($options['secret']),
     wp_get_current_user()
   );
   $snippet = new Snippet($snippet_settings);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <phpunit bootstrap="./bootstrap.php">
     <testsuites>
-        <testsuite name="Intercom Wordpress Testsuite">
+        <testsuite name="Intercom WordPress Testsuite">
             <directory>./test</directory>
         </testsuite>
     </testsuites>

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
-# Intercom / Wordpress
+# Intercom / WordPress
 
 [![Build Status](https://travis-ci.org/intercom/intercom-wordpress.svg?branch=master)](https://travis-ci.org/intercom/intercom-wordpress)
 
 # Beta
 
-This plugin for Wordpress is in active development.
+This plugin for WordPress is in active development.
 
 # Local Testing
 
@@ -26,7 +26,7 @@ Once filled out, the Intercom widget will automatically appear on your site.
 
 If a `$current_user` is present, we use their email as an identifier in the widget.
 
-Otherwise the widget operates in [Acquire mode](https://www.intercom.io/live-chat) (if available). This allows you to talk with anonymous visitors on your Wordpress site.
+Otherwise the widget operates in [Acquire mode](https://www.intercom.io/live-chat) (if available). This allows you to talk with anonymous visitors on your WordPress site.
 
 # Contributing
 

--- a/readme.txt
+++ b/readme.txt
@@ -9,7 +9,7 @@ Official Intercom support for WordPress
 
 == Description ==
 
-With the Intercom plugin for Wordpress, you can chat to both logged-in and anonymous users (using [Acquire](https://www.intercom.io/live-chat)).
+With the Intercom plugin for WordPress, you can chat to both logged-in and anonymous users (using [Acquire](https://www.intercom.io/live-chat)).
 
 Installing this plugin provides a new Intercom settings page, which allows you to configure your app id and secure mode secret. Once filled out, the Intercom widget will automatically appear.
 

--- a/test/SnippetSettingsTest.php
+++ b/test/SnippetSettingsTest.php
@@ -1,5 +1,5 @@
 <?php
-class FakeWordpressUserForSnippetTest
+class FakeWordPressUserForSnippetTest
 {
   public $user_email = "foo@bar.com";
 }
@@ -13,7 +13,7 @@ class SnippetSettingsTest extends PHPUnit_Framework_TestCase
   }
   public function testJSONRenderingWithSecureMode()
   {
-    $snippet_settings = new SnippetSettings(array("app_id" => "bar"), "foo", new FakeWordpressUserForSnippetTest());
+    $snippet_settings = new SnippetSettings(array("app_id" => "bar"), "foo", new FakeWordPressUserForSnippetTest());
     $this->assertEquals("{\"app_id\":\"bar\",\"email\":\"foo@bar.com\",\"user_hash\":\"a95b0a1ab461c0721d91fbe32a5f5f2a27ac0bfa4bfbcfced168173fa80d4e14\"}", $snippet_settings->json());
   }
 

--- a/test/UserTest.php
+++ b/test/UserTest.php
@@ -1,9 +1,9 @@
 <?php
-class FakeWordpressUser
+class FakeWordPressUser
 {
   public $user_email = "foo@bar.com";
 }
-class FakeWordpressUserNoEmail
+class FakeWordPressUserNoEmail
 {
   public $user_email = NULL;
 }
@@ -13,7 +13,7 @@ class UserTest extends PHPUnit_Framework_TestCase
   public function testEmail()
   {
     $settings = array();
-    $user = new IntercomUser(new FakeWordpressUser(), $settings);
+    $user = new IntercomUser(new FakeWordPressUser(), $settings);
     $built_settings = $user->buildSettings();
     $this->assertEquals("foo@bar.com", $built_settings["email"]);
   }
@@ -27,7 +27,7 @@ class UserTest extends PHPUnit_Framework_TestCase
   public function testNoUserEmail()
   {
     $settings = array();
-    $user = new IntercomUser(new FakeWordpressUserNoEmail(), $settings);
+    $user = new IntercomUser(new FakeWordPressUserNoEmail(), $settings);
     $built_settings = $user->buildSettings();
     $this->assertEquals(false, array_key_exists('email', $built_settings));
   }

--- a/test/ValidatorTest.php
+++ b/test/ValidatorTest.php
@@ -3,7 +3,7 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
 {
   public function testValidator()
   {
-    // Emulate the wordpress wp_kses function
+    // Emulate the WordPress wp_kses function
     $wp_kses = function($x) {
       return str_replace("<script>", "", $x);
     };


### PR DESCRIPTION
WordPress has both a capital W and capital P - see
https://codex.wordpress.org/Function_Reference/capital_P_dangit

left usage of “wordpress” alone, but changed all occurrences of
“Wordpress” to the correct "WordPress"