### PR TITLE
patch oauth

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -455,10 +455,19 @@ function intercom_settings() {
     update_option("intercom", $options);
   }
 }
+// Enable Secure Mode for customers who already copy/pasted their secret_key before the Oauth2 release.
+function patch_oauth() {
+  $options = get_option('intercom');
+  if ($options["secret"] && !isset($options["secure_mode"])) {
+    $options["secure_mode"] = true;
+    update_option("intercom", $options);
+  }
+}
 
 if (getenv('INTERCOM_PLUGIN_TEST') != '1') {
   add_action('wp_footer', 'add_intercom_snippet');
   add_action('admin_menu', 'add_intercom_settings_page');
   add_action('network_admin_menu', 'add_intercom_settings_page');
+  add_action('admin_init', 'patch_oauth');
   add_action('admin_init', 'intercom_settings');
 }

--- a/test/SecureModeCalulatorTest.php
+++ b/test/SecureModeCalulatorTest.php
@@ -4,28 +4,28 @@ class SecureModeCalulatorTest extends PHPUnit_Framework_TestCase
   public function testHashEmail()
   {
     $data = array("email" => "test@intercom.io");
-    $calculator = new SecureModeCalculator($data, "s3cre7");
+    $calculator = new SecureModeCalculator($data, "s3cre7", true);
     $this->assertEquals(array("user_hash" => "844240a2deab99438ade8e7477aa832e22adb0e1eb1ad7754ff8d4054fb63869"), $calculator->secureModeComponent());
   }
 
   public function testHashUserId()
   {
     $data = array("user_id" => "abcdef", "email" => "test@intercom.io");
-    $calculator = new SecureModeCalculator($data, "s3cre7");
+    $calculator = new SecureModeCalculator($data, "s3cre7", true);
     $this->assertEquals(array("user_hash" => "532cd9cd6bfa49528cf2503db0743bb72456bda2cb7424d2894c5b11f6cad6cf"), $calculator->secureModeComponent());
   }
 
   public function testEmpty()
   {
     $data = array();
-    $calculator = new SecureModeCalculator($data, "s3cre7");
+    $calculator = new SecureModeCalculator($data, "s3cre7", true);
     $this->assertEquals(array(), $calculator->secureModeComponent());
   }
 
   public function testNoSecureMode()
   {
     $data = array("email" => "test@intercom.io");
-    $calculator = new SecureModeCalculator($data, "");
+    $calculator = new SecureModeCalculator($data, "s3cre7", false);
     $this->assertEquals(array(), $calculator->secureModeComponent());
   }
 }

--- a/test/SnippetSettingsTest.php
+++ b/test/SnippetSettingsTest.php
@@ -13,7 +13,7 @@ class SnippetSettingsTest extends PHPUnit_Framework_TestCase
   }
   public function testJSONRenderingWithSecureMode()
   {
-    $snippet_settings = new SnippetSettings(array("app_id" => "bar"), "foo", new FakeWordPressUserForSnippetTest());
+    $snippet_settings = new SnippetSettings(array("app_id" => "bar"), "foo", true, new FakeWordPressUserForSnippetTest());
     $this->assertEquals("{\"app_id\":\"bar\",\"email\":\"foo@bar.com\",\"user_hash\":\"a95b0a1ab461c0721d91fbe32a5f5f2a27ac0bfa4bfbcfced168173fa80d4e14\"}", $snippet_settings->json());
   }
 

--- a/test/SnippetTest.php
+++ b/test/SnippetTest.php
@@ -3,7 +3,7 @@ class SnippetTest extends PHPUnit_Framework_TestCase
 {
   public function testGeneratedHtml()
   {
-    $settings = new SnippetSettings(array("app_id" => "foo", "name" => "Nikola Tesla"), NULL, NULL, array());
+    $settings = new SnippetSettings(array("app_id" => "foo", "name" => "Nikola Tesla"), NULL, NULL, NULL, array());
     $snippet = new Snippet($settings);
 
     $expectedHtml = <<<HTML


### PR DESCRIPTION
Enable Secure Mode for customers who already copy/pasted their secret_key before the Oauth2 release.