### PR TITLE
fixed setup guide workflow problem

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,10 @@ Running tests requires [phpunit](https://phpunit.de/).
 INTERCOM_PLUGIN_TEST=1 phpunit
 ```
 
+# Test the new version of the plugin with Intercom's Wordpress signup flow
+
+It is mandatory that you fully test the [intercom wordpress setup guide](https://app.intercom.io/a/start/wordpress) before you release a new update of the plugin.
+
 # Usage
 
 Installing this plugin provides a new Intercom settings page.


### PR DESCRIPTION
We should update the "copy your app_id" part of the setup guide with a "update your app_id in the integration" since we don't request to save manually anymore (any security issue I'm not aware of here ? @bobjflong ).

When user sign up using the setup guide. The app_id is copied and he can then use the oauth to enable secure mode.
