### PR TITLE
Add key to remove PHP missing index notice

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -249,6 +249,8 @@ END;
     // Use Case : secure mode enabled : checkbox checked and disabled (can not reverse secure mode)
     if($secure_mode) {
       $styles['secure_mode_state'] = 'checked disabled';
+    } else {
+      $styles['secure_mode_state'] = '';
     }
 
     // Use Case : app_id here but secure mode disabled


### PR DESCRIPTION
Without the `$style['secure_mode_state']` key, a PHP notice is thrown on the main settings page for the plugin.
