### PR TITLE
Add prefix to avoid conflict with other plugins

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -320,7 +320,7 @@ END;
   }
 }
 
-class Snippet
+class IntercomSnippet
 {
   private $snippet_settings = "";
 
@@ -364,7 +364,7 @@ HTML;
   }
 }
 
-class SnippetSettings
+class IntercomSnippetSettings
 {
   private $raw_data = array();
   private $secret = NULL;
@@ -507,13 +507,13 @@ if (getenv('INTERCOM_PLUGIN_TEST') != '1') {
 function add_intercom_snippet()
 {
   $options = get_option('intercom');
-  $snippet_settings = new SnippetSettings(
+  $snippet_settings = new IntercomSnippetSettings(
     array("app_id" => WordPressEscaper::escJS($options['app_id'])),
     WordPressEscaper::escJS($options['secret']),
     WordPressEscaper::escJS($options['secure_mode']),
     wp_get_current_user()
   );
-  $snippet = new Snippet($snippet_settings);
+  $snippet = new IntercomSnippet($snippet_settings);
   echo $snippet->html();
 }
 

--- a/test/SnippetSettingsTest.php
+++ b/test/SnippetSettingsTest.php
@@ -4,29 +4,29 @@ class FakeWordPressUserForSnippetTest
   public $user_email = "foo@bar.com";
 }
 
-class SnippetSettingsTest extends PHPUnit_Framework_TestCase
+class IntercomSnippetSettingsTest extends PHPUnit_Framework_TestCase
 {
   public function testJSONRendering()
   {
-    $snippet_settings = new SnippetSettings(array("app_id" => "bar"));
+    $snippet_settings = new IntercomSnippetSettings(array("app_id" => "bar"));
     $this->assertEquals("{\"app_id\":\"bar\"}", $snippet_settings->json());
   }
   public function testJSONRenderingWithSecureMode()
   {
-    $snippet_settings = new SnippetSettings(array("app_id" => "bar"), "foo", true, new FakeWordPressUserForSnippetTest());
+    $snippet_settings = new IntercomSnippetSettings(array("app_id" => "bar"), "foo", true, new FakeWordPressUserForSnippetTest());
     $this->assertEquals("{\"app_id\":\"bar\",\"email\":\"foo@bar.com\",\"user_hash\":\"a95b0a1ab461c0721d91fbe32a5f5f2a27ac0bfa4bfbcfced168173fa80d4e14\"}", $snippet_settings->json());
   }
 
   public function testIclLanguageConstant()
   {
     define('ICL_LANGUAGE_CODE', 'fr');
-    $snippet_settings = new SnippetSettings(array("app_id" => "bar"));
+    $snippet_settings = new IntercomSnippetSettings(array("app_id" => "bar"));
     $this->assertEquals("{\"app_id\":\"bar\",\"language_override\":\"fr\"}", $snippet_settings->json());
   }
 
   public function testAppId()
   {
-    $snippet_settings = new SnippetSettings(array("app_id" => "bar"));
+    $snippet_settings = new IntercomSnippetSettings(array("app_id" => "bar"));
     $this->assertEquals("bar", $snippet_settings->appId());
   }
 
@@ -35,6 +35,6 @@ class SnippetSettingsTest extends PHPUnit_Framework_TestCase
   */
   public function testValidation()
   {
-    $snippet = new SnippetSettings(array("foo" => "bar"));
+    $snippet = new IntercomSnippetSettings(array("foo" => "bar"));
   }
 }

--- a/test/SnippetTest.php
+++ b/test/SnippetTest.php
@@ -1,10 +1,10 @@
 <?php
-class SnippetTest extends PHPUnit_Framework_TestCase
+class IntercomSnippetTest extends PHPUnit_Framework_TestCase
 {
   public function testGeneratedHtml()
   {
-    $settings = new SnippetSettings(array("app_id" => "foo", "name" => "Nikola Tesla"), NULL, NULL, NULL, array());
-    $snippet = new Snippet($settings);
+    $settings = new IntercomSnippetSettings(array("app_id" => "foo", "name" => "Nikola Tesla"), NULL, NULL, NULL, array());
+    $snippet = new IntercomSnippet($settings);
 
     $expectedHtml = <<<HTML
 <script data-cfasync="false">


### PR DESCRIPTION
## About

This PR fixes the bug reported in https://wordpress.org/support/topic/this-plugin-breaks-the-popular-code-snippets-plugin/#post-8957853 by adding a prefix to the `Snippet` class

## Testing

- [x] Install the Intercom plugin (zipping this repo branch)
- [x] Install the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plug-in (via WP admin)
- [x] Set-up the Intercom plugin and ensure the messenger is displayed on your WP site
- [x] Click "Add new" on the Snippet admin interface and make sure the page is not blank

