### PR TITLE
update wordpress readme to make instructions more clear

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -21,8 +21,8 @@ Your logged-in customers will be tracked in Intercom as users, and visitors who 
 
 Installing Intercom on your WordPress site takes just a few minutes.
 
-If you aren’t already an Intercom customer, you can find full instructions on signing up and installing Intercom using the WordPress plugin [here](https://docs.intercom.io/install-on-your-product-or-site/other-ways-to-get-started/install-intercom-on-your-wordpress-site).
+You can find full instructions on signing up and installing Intercom using the WordPress plugin [here](https://docs.intercom.io/install-on-your-product-or-site/other-ways-to-get-started/install-intercom-on-your-wordpress-site).
 
-If you’re already an Intercom customer, you can find instructions in the in-app [setup guide](https://app.intercom.com/a/apps/_/platform/guide). The first thing you’ll need to do is install and activate the plugin - you must be using WordPress v4.2.0 or higher and have the ability to install plugins in order to use this method.
+If you’re already an Intercom customer, you can also find instructions in the in-app [setup guide](https://app.intercom.com/a/apps/_/platform/guide) or [app store](https://app.intercom.com/a/apps/_/appstore?app_package_code=wordpress&search=wordpress). The first thing you’ll need to do is install and activate the plugin - you must be using WordPress v4.2.0 or higher and have the ability to install plugins in order to use this method.
 
 Note: This plugin injects a Javascript snippet on your website frontend containing dynamic user data. Some caching solutions will cache entire pages and should not be used with this plugin. Doing so may cause conversations to be delivered to the wrong user.


### PR DESCRIPTION
closes https://github.com/intercom/intercom/issues/93464

The documentation issue we see outlined in the above issue has been resolved -- we give the step-by-step breakthrough in the documentation: https://docs.intercom.com/install-on-your-product-or-site/other-ways-to-get-started/install-intercom-on-your-wordpress-site

The only other actionable item is to add a link to the app store for more visibility into getting to that article. I've also removed the "If you aren’t already an Intercom customer" text, as the documentation in the wordpress article applies to all kinds of users.