### PR TITLE
Update broken URL to the wordpress start guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ INTERCOM_PLUGIN_TEST=1 phpunit
 
 # Test the new version of the plugin with Intercom's Wordpress signup flow
 
-It is mandatory that you fully test the [intercom wordpress setup guide](https://app.intercom.io/a/start/wordpress) before you release a new update of the plugin.
+It is mandatory that you fully test the [Intercom wordpress start guide](https://app.intercom.io/a/apps/_/platform/guide/setup_messenger/install_messenger) before you release a new update of the plugin.
 
 # Usage
 


### PR DESCRIPTION
When reading the README, I noticed that a URL that takes us to the wordpress start guide doesn't work anymore. As far as I know, this has been replaced by the start guide in the Install Messenger page.