### PR TITLE
Rename app.intercom.io to app.intercom.com.

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -146,7 +146,7 @@ END;
                   Intercom is now set up and ready to go. You can now chat with your existing and potential new customers, send them targeted messages, and get feedback.
                   <br/>
                   <br/>
-                  <a class="c__blue" href="https://app.intercom.io/a/apps/$app_id" target="_blank">Click here to access your Intercom Team Inbox.</a>
+                  <a class="c__blue" href="https://app.intercom.com/a/apps/$app_id" target="_blank">Click here to access your Intercom Team Inbox.</a>
                   <br/>
                   <br/>
                   Need help? <a class="c__blue" href="https://docs.intercom.io/for-converting-visitors-to-users" target="_blank">Visit our documentation</a> for best practices, tips, and much more.
@@ -287,7 +287,7 @@ END;
     $settings = $this->getSettings();
     $app_id = $settings['app_id'];
     if(!$app_id) {
-      return '<p>Need an Intercom account? <a target="_blank" href="https://app.intercom.io/a/get_started/add_people?signupMethod=integrate&userSource=wordpress">Get started</a>.</p>';
+      return '<p>Need an Intercom account? <a target="_blank" href="https://app.intercom.com/a/get_started/add_people?signupMethod=integrate&userSource=wordpress">Get started</a>.</p>';
     } else {
       return '';
     }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -102,7 +102,6 @@ END;
     if (isset($_GET['authenticated'])) {
       $dismissable_message = $this->dismissibleMessage('You successfully authenticated with Intercom');
     }
-    $onboarding_markup = $this->getOnboardingLinkIfNoAppId();
 
     return <<<END
 
@@ -133,7 +132,6 @@ END;
                   <img src="https://static.intercomassets.com/assets/oauth/primary-7edb2ebce84c088063f4b86049747c3a.png" srcset="https://static.intercomassets.com/assets/oauth/primary-7edb2ebce84c088063f4b86049747c3a.png 1x, https://static.intercomassets.com/assets/oauth/primary@2x-0d69ca2141dfdfa0535634610be80994.png 2x, https://static.intercomassets.com/assets/oauth/primary@3x-788ed3c44d63a6aec3927285e920f542.png 3x"/>
                 </a>
               </div>
-              $onboarding_markup
             </div>
 
             <div class="t__h1 c__red" style="$styles[app_id_copy_title]">Intercom setup</div>
@@ -280,17 +278,6 @@ END;
   private function getStyles()
   {
     return $this->styles;
-  }
-
-  private function getOnboardingLinkIfNoAppId()
-  {
-    $settings = $this->getSettings();
-    $app_id = $settings['app_id'];
-    if(!$app_id) {
-      return '<p>Need an Intercom account? <a target="_blank" href="https://app.intercom.com/a/get_started/add_people?signupMethod=integrate&userSource=wordpress">Get started</a>.</p>';
-    } else {
-      return '';
-    }
   }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -14,9 +14,9 @@ Running tests requires [phpunit](https://phpunit.de/).
 INTERCOM_PLUGIN_TEST=1 phpunit
 ```
 
-# Test the new version of the plugin with Intercom's Wordpress signup flow
+# Test the new version of the plugin with Intercom's WordPress signup flow
 
-It is mandatory that you fully test the [Intercom wordpress start guide](https://app.intercom.com/a/apps/_/platform/guide/setup_messenger/install_messenger) before you release a new update of the plugin.
+It is mandatory that you fully test the [Intercom WordPress Onboarding Home step](https://app.intercom.com/a/apps/_/home?step=set_up_messenger_visitors) before you release a new update of the plugin.
 
 # Usage
 
@@ -32,7 +32,7 @@ NB: This plugin injects a Javascript snippet on your website frontend containing
 
 # Pass extra parameters to the Intercom Messenger
 
-Using the [Wordpress Hooks API](https://codex.wordpress.org/Plugin_API) `add_filter` method in your Wordpress theme you can pass extra parameters to the Intercom Messenger (see example below):
+Using the [WordPress Hooks API](https://codex.wordpress.org/Plugin_API) `add_filter` method in your WordPress theme you can pass extra parameters to the Intercom Messenger (see example below):
 
 ```php
 add_filter( 'intercom_settings', function( $settings ) {

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ INTERCOM_PLUGIN_TEST=1 phpunit
 
 # Test the new version of the plugin with Intercom's Wordpress signup flow
 
-It is mandatory that you fully test the [Intercom wordpress start guide](https://app.intercom.io/a/apps/_/platform/guide/setup_messenger/install_messenger) before you release a new update of the plugin.
+It is mandatory that you fully test the [Intercom wordpress start guide](https://app.intercom.com/a/apps/_/platform/guide/setup_messenger/install_messenger) before you release a new update of the plugin.
 
 # Usage
 
@@ -35,9 +35,9 @@ NB: This plugin injects a Javascript snippet on your website frontend containing
 Using the [Wordpress Hooks API](https://codex.wordpress.org/Plugin_API) `add_filter` method in your Wordpress theme you can pass extra parameters to the Intercom Messenger (see example below):
 
 ```php
-add_filter( 'intercom_settings', function( $settings ) {                                                  
-  $settings['user_id'] = $user_id;                
-  return $settings;                                                      
+add_filter( 'intercom_settings', function( $settings ) {
+  $settings['user_id'] = $user_id;
+  return $settings;
 } );
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -14,10 +14,6 @@ Running tests requires [phpunit](https://phpunit.de/).
 INTERCOM_PLUGIN_TEST=1 phpunit
 ```
 
-# Test the new version of the plugin with Intercom's WordPress signup flow
-
-It is mandatory that you fully test the [Intercom WordPress Onboarding Home step](https://app.intercom.com/a/apps/_/home?step=set_up_messenger_visitors) before you release a new update of the plugin.
-
 # Usage
 
 Installing this plugin provides a new Intercom settings page.


### PR DESCRIPTION
There's an engineering goal to migrate from app.intercom.io to app.intercom.com
File status: https://docs.google.com/spreadsheets/d/1sVYmx4-53598JgS97tOfFjmu4drgnSUTZEiUBLMBAUs/edit#gid=0