### PR TITLE
Update readme bumped tested to 6.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: bobintercom
 License: Apache 2.0
 Tags: intercom, customer, chat
 Requires at least: 4.2.0
-Tested up to: 5.8.1
+Tested up to: 6.0
 
 The official WordPress plugin, built by Intercom.
 


### PR DESCRIPTION
# Why?
WordPress 6.0 is scheduled to be released on May 24th
Tested the plugin with `6.0-RC1` from [beta releases](https://wordpress.org/download/releases/#betas)
Updated readme to reflect the same.

Towards https://github.com/intercom/intercom/issues/238089