### PR TITLE
Add pluggin to provide installation_type setting attribute

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -361,6 +361,7 @@ class IntercomSnippetSettings
     $identityVerificationCalculator = new IdentityVerificationCalculator($settings, $this->secret);
     $result = array_merge($settings, $identityVerificationCalculator->identityVerificationComponent());
     $result = $this->mergeConstants($result);
+    $result['installation_type'] = 'wordpress';
     return $result;
   }
 

--- a/test/SnippetSettingsTest.php
+++ b/test/SnippetSettingsTest.php
@@ -9,24 +9,28 @@ class IntercomSnippetSettingsTest extends PHPUnit_Framework_TestCase
   public function testJSONRendering()
   {
     $snippet_settings = new IntercomSnippetSettings(array("app_id" => "bar"));
-    $this->assertEquals("{\"app_id\":\"bar\"}", $snippet_settings->json());
+    $this->assertEquals("{\"app_id\":\"bar\",\"installation_type\":\"wordpress\"}", $snippet_settings->json());
   }
   public function testJSONRenderingWithIdentityVerification()
   {
     $snippet_settings = new IntercomSnippetSettings(array("app_id" => "bar"), "foo", new FakeWordPressUserForSnippetTest());
-    $this->assertEquals("{\"app_id\":\"bar\",\"email\":\"foo@bar.com\",\"user_hash\":\"a95b0a1ab461c0721d91fbe32a5f5f2a27ac0bfa4bfbcfced168173fa80d4e14\"}", $snippet_settings->json());
+    $this->assertEquals("{\"app_id\":\"bar\",\"email\":\"foo@bar.com\",\"user_hash\":\"a95b0a1ab461c0721d91fbe32a5f5f2a27ac0bfa4bfbcfced168173fa80d4e14\",\"installation_type\":\"wordpress\"}", $snippet_settings->json());
   }
   public function testJSONRenderingWithIdentityVerificationAndNoSecret()
   {
     $snippet_settings = new IntercomSnippetSettings(array("app_id" => "bar"), NULL, new FakeWordPressUserForSnippetTest());
-    $this->assertEquals("{\"app_id\":\"bar\",\"email\":\"foo@bar.com\"}", $snippet_settings->json());
+    $this->assertEquals("{\"app_id\":\"bar\",\"email\":\"foo@bar.com\",\"installation_type\":\"wordpress\"}", $snippet_settings->json());
   }
-
+  public function testInstallationType()
+  {
+    $snippet_settings = new IntercomSnippetSettings(array("app_id" => "bar"));
+    $this->assertEquals("{\"app_id\":\"bar\",\"installation_type\":\"wordpress\"}", $snippet_settings->json());
+  }
   public function testIclLanguageConstant()
   {
     define('ICL_LANGUAGE_CODE', 'fr');
     $snippet_settings = new IntercomSnippetSettings(array("app_id" => "bar"));
-    $this->assertEquals("{\"app_id\":\"bar\",\"language_override\":\"fr\"}", $snippet_settings->json());
+    $this->assertEquals("{\"app_id\":\"bar\",\"language_override\":\"fr\",\"installation_type\":\"wordpress\"}", $snippet_settings->json());
   }
 
   public function testAppId()

--- a/test/SnippetTest.php
+++ b/test/SnippetTest.php
@@ -22,9 +22,9 @@ class IntercomSnippetTest extends PHPUnit_Framework_TestCase
   };
 </script>
 <script data-cfasync="false">
-  window.intercomSettings = {"app_id":"foo","name":"Nikola Tesla"};
+  window.intercomSettings = {"app_id":"foo","name":"Nikola Tesla","installation_type":"wordpress"};
 </script>
-<script data-cfasync="false">(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/foo';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>
+<script data-cfasync="false">(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/foo';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s, x);};if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>
 HTML;
 
     $this->assertEquals($expectedHtml, $snippet->html());


### PR DESCRIPTION
# Why?
Towards https://github.com/intercom/intercom/issues/322688

We want to better understand how people install intercom web messenger, for that we added a new `installation_type` setting option, when it is set we send that data to our backend to further analyze and store.


### Tests passed locally
<img width="467" alt="Screenshot 2024-02-13 at 18 42 17" src="https://github.com/intercom/intercom-shopify/assets/4772270/eca9dafb-1529-4d1d-8877-c9143147b019">

CI seems to be broken for ages we might need to updated php, phpunit and move CI to circle CI


