### PR TITLE
Update tested up to version to remove warning banner

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: bobintercom
 License: Apache 2.0
 Tags: intercom, customer, chat
 Requires at least: 4.2.0
-Tested up to: 6.0
+Tested up to: 6.4.3
 
 The official WordPress plugin, built by Intercom.
 


### PR DESCRIPTION
# Why?

Our current Wordpress banner is marked with the following warning banner:
![ ](https://github.com/intercom/intercom-wordpress/assets/4772270/b507b538-2ae2-4399-b45d-66f2df2bee99)

I have tested latest version of our plugin locally on Wordpress 6.4.3, and it works fine:
![Screenshot 2024-02-14 at 16 56 49](https://github.com/intercom/intercom-wordpress/assets/4772270/67fb1e0f-0352-4026-8e36-43e1f95db5d7)
![Screenshot 2024-02-14 at 16 57 22](https://github.com/intercom/intercom-wordpress/assets/4772270/f26845db-a888-4201-997b-1b3045ee31d3)

