### PR TITLE
update version attribute name to avoid it landing in the user_data

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -5,10 +5,10 @@ Plugin URI: https://wordpress.org/plugins/intercom
 Description: Official <a href="https://www.intercom.io">Intercom</a> support for WordPress.
 Author: Intercom
 Author URI: https://www.intercom.io
-Version: 3.0.1
+Version: 3.0.2
  */
 
-define('INTERCOM_PLUGIN_VERSION', '3.0.1');
+define('INTERCOM_PLUGIN_VERSION', '3.0.2');
 
 require_once __DIR__ . '/vendor/autoload.php';
 use Firebase\JWT\JWT;
@@ -406,7 +406,7 @@ class IntercomSnippetSettings
     $settings = $messengerSecurityCalculator->messengerSecurityComponent();
     $result = $this->mergeConstants(apply_filters("intercom_settings", $settings));
     $result['installation_type'] = 'wordpress';
-    $result['integration_version'] = INTERCOM_PLUGIN_VERSION;
+    $result['installation_version'] = INTERCOM_PLUGIN_VERSION;
     return $result;
   }
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 4.7.0
 Tested up to: 6.7.2
 Requires PHP: 7.2
 License: Apache 2.0
-Stable tag: 3.0.1
+Stable tag: 3.0.2
 
 Official Intercom WordPress plugin: Engage visitors in real time, power growth with AI, and convert leads into loyal customers.
 
@@ -32,6 +32,11 @@ Note: This plugin injects a Javascript snippet on your website frontend containi
 2. Plugin settings successfully authenticated with Intercom settings_auth.png
 3. Intercom widget used by customers to communicate with the business widget.png
 == Changelog ==
+= 3.0.2 =
+
+https://github.com/intercom/intercom-wordpress/pull/131
+* Updated version attribute to avoid it getting sent in the user data.
+
 = 3.0.1 =
 
 https://github.com/intercom/intercom-wordpress/pull/130
@@ -48,6 +53,8 @@ https://github.com/intercom/intercom-wordpress/pull/127
 * Added missing tests.
 
 == Upgrade Notice ==
+= 3.0.1 =
+Updated version attribute name to avoid setting it as part of user data.
 
 = 3.0.1 =
 Help Intercom provide better support by sharing the plugin version is in use.

--- a/test/SnippetSettingsTest.php
+++ b/test/SnippetSettingsTest.php
@@ -26,7 +26,7 @@ class IntercomSnippetSettingsTest extends TestCase
   public function testJSONRendering()
   {
     $snippet_settings = new IntercomSnippetSettings(array("app_id" => "bar"));
-    $this->assertEquals("{\"app_id\":\"bar\",\"installation_type\":\"wordpress\",\"integration_version\":\"" . INTERCOM_PLUGIN_VERSION . "\"}", $snippet_settings->json());
+    $this->assertEquals("{\"app_id\":\"bar\",\"installation_type\":\"wordpress\",\"installation_version\":\"" . INTERCOM_PLUGIN_VERSION . "\"}", $snippet_settings->json());
   }
   public function testJSONRenderingWithIdentityVerification()
   {
@@ -37,23 +37,23 @@ class IntercomSnippetSettingsTest extends TestCase
       "exp" => TimeProvider::getCurrentTime() + 3600
     );
     $jwt = JWT::encode($jwt_data, "s3cre7", 'HS256'); 
-    $this->assertEquals('{"app_id":"bar","intercom_user_jwt":"'.$jwt.'","installation_type":"wordpress","integration_version":"' . INTERCOM_PLUGIN_VERSION . '"}', $snippet_settings->json());
+    $this->assertEquals('{"app_id":"bar","intercom_user_jwt":"'.$jwt.'","installation_type":"wordpress","installation_version":"' . INTERCOM_PLUGIN_VERSION . '"}', $snippet_settings->json());
   }
   public function testJSONRenderingWithIdentityVerificationAndNoSecret()
   {
     $snippet_settings = new IntercomSnippetSettings(array("app_id" => "bar"), NULL, new FakeWordPressUserForSnippetTest());
-    $this->assertEquals("{\"app_id\":\"bar\",\"email\":\"foo@bar.com\",\"installation_type\":\"wordpress\",\"integration_version\":\"" . INTERCOM_PLUGIN_VERSION . "\"}", $snippet_settings->json());
+    $this->assertEquals("{\"app_id\":\"bar\",\"email\":\"foo@bar.com\",\"installation_type\":\"wordpress\",\"installation_version\":\"" . INTERCOM_PLUGIN_VERSION . "\"}", $snippet_settings->json());
   }
   public function testInstallationType()
   {
     $snippet_settings = new IntercomSnippetSettings(array("app_id" => "bar"));
-    $this->assertEquals("{\"app_id\":\"bar\",\"installation_type\":\"wordpress\",\"integration_version\":\"" . INTERCOM_PLUGIN_VERSION . "\"}", $snippet_settings->json());
+    $this->assertEquals("{\"app_id\":\"bar\",\"installation_type\":\"wordpress\",\"installation_version\":\"" . INTERCOM_PLUGIN_VERSION . "\"}", $snippet_settings->json());
   }
   public function testIclLanguageConstant()
   {
     define('ICL_LANGUAGE_CODE', 'fr');
     $snippet_settings = new IntercomSnippetSettings(array("app_id" => "bar"));
-    $this->assertEquals("{\"app_id\":\"bar\",\"language_override\":\"fr\",\"installation_type\":\"wordpress\",\"integration_version\":\"" . INTERCOM_PLUGIN_VERSION . "\"}", $snippet_settings->json());
+    $this->assertEquals("{\"app_id\":\"bar\",\"language_override\":\"fr\",\"installation_type\":\"wordpress\",\"installation_version\":\"" . INTERCOM_PLUGIN_VERSION . "\"}", $snippet_settings->json());
   }
 
   public function testAppId()

--- a/test/SnippetTest.php
+++ b/test/SnippetTest.php
@@ -24,7 +24,7 @@ class IntercomSnippetTest extends TestCase
   };
 </script>
 <script data-cfasync="false">
-  window.intercomSettings = {"app_id":"foo","name":"Nikola Tesla","installation_type":"wordpress","integration_version":"3.0.1"};
+  window.intercomSettings = {"app_id":"foo","name":"Nikola Tesla","installation_type":"wordpress","installation_version":"3.0.2"};
 </script>
 <script data-cfasync="false">(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/foo';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s, x);};if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>
 HTML;


### PR DESCRIPTION
I made a change to the Intercom messenger to taking the `installation_version` attribute out of the user data. I changed the attribute name to follow the same naming convention we have for the integration type.

We made the decision of removing that attribute from the `user_data` to avoid having this attribute attached to the user object